### PR TITLE
Don't completely bail if a single article can't be converted to HTML.

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -20,6 +20,10 @@ class UnknownNode(Exception):
     pass
 
 
+class HtmlComposingError(Exception):
+    pass
+
+
 class WikicodeToHtmlComposer(object):
     """
     Format HTML from Parsed Wikicode.
@@ -57,7 +61,7 @@ class WikicodeToHtmlComposer(object):
         if tag not in self._stack:
             # TODO
             if raise_on_missing:
-                raise RuntimeError('Uh oh')
+                raise HtmlComposingError('Unable to close given tags.')
             else:
                 return
 
@@ -260,10 +264,13 @@ def get_articles():
 
         composer = WikicodeToHtmlComposer()
 
-        feed.add_item(title=u'Current events: {}'.format(day),
-                      link=get_article_url(day),
-                      description=composer.compose(nodes),
-                      pubdate=datetime(*day.timetuple()[:3]))
+        try:
+            feed.add_item(title=u'Current events: {}'.format(day),
+                          link=get_article_url(day),
+                          description=composer.compose(nodes),
+                          pubdate=datetime(*day.timetuple()[:3]))
+        except HtmlComposingError:
+            print("Unable to render article from: {}".format(day))
 
     return feed.writeString('utf-8')
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # For running tests.
-pytest==3.0.7
+pytest==3.1.3
 
 # Style checking.
 flake8==3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
 # For parsing articles from Wikipedia.
-mwparserfromhell==0.4.4
+mwparserfromhell==0.5
 
 # For generating RSS.
 feedgenerator==1.9
 
 # For downloading articles from Wikipedia.
-requests==2.14.2
+requests==2.18.1
 
 # For serving the resulting feed.
-Flask==0.12.1
+Flask==0.12.2
 
 # For deploying.
 gunicorn==19.7.1


### PR DESCRIPTION
This is a partial fix for #3.

Now we'll only ignore the individual article that fails to be converted to HTML instead of serving a 500 page.

This also updates some packages since mwparserfromhell was made a bit more robust against "bad" wikicode.